### PR TITLE
Reimplements validation repo

### DIFF
--- a/apps/api/src/adapters/clients/github/__tests__/get-repository.test.ts
+++ b/apps/api/src/adapters/clients/github/__tests__/get-repository.test.ts
@@ -1,0 +1,179 @@
+import { describe, test } from '@jest/globals';
+import { createGetRepository } from '../get-repository';
+import githubErrors from '../errors';
+import type { HttpClient } from '../interfaces/dependencies';
+
+describe('getRepository', () => {
+  test('request a repository using the owner and the repository name given', async () => {
+    const username = 'octocat';
+    const repositoryName = 'hello-world';
+    const accessToken = 'gho_912e0asd0q821edqd';
+    const httpClient = {
+      get: jest.fn().mockResolvedValue({ status: 200, data: [] }),
+    };
+    const getRepository = createGetRepository(
+      httpClient as unknown as HttpClient,
+    );
+
+    getRepository(accessToken, username, repositoryName);
+
+    expect(httpClient.get).toHaveBeenCalledWith(
+      `https://api.github.com/repos/${username}/${repositoryName}`,
+      {
+        headers: {
+          authorization: `token ${accessToken}`,
+          accept: 'application/vnd.github+json',
+        },
+      },
+    );
+  });
+
+  test('returns a repository with name, owner and if the repo is public', async () => {
+    const username = 'octocat';
+    const repositoryName = 'hello-world';
+    const accessToken = 'gho_912e0asd0q821edqd';
+    const response = {
+      status: 200,
+      data: {
+        name: repositoryName,
+        owner: {
+          login: username,
+          id: 1,
+          type: 'User',
+          avatar_url: 'https://github.com/images/error/octocat_happy.gif',
+        },
+        private: false,
+        fork: false,
+      },
+    };
+    const httpClient = { get: jest.fn().mockResolvedValue(response) };
+    const getRepository = createGetRepository(
+      httpClient as unknown as HttpClient,
+    );
+
+    const result = await getRepository(accessToken, username, repositoryName);
+
+    expect(result.isOk()).toBe(true);
+    expect(result.value).toEqual({
+      name: repositoryName,
+      owner: username,
+      isPublic: true,
+      isFork: false,
+    });
+  });
+
+  test('indicates when the repository is a fork and returns original owner', async () => {
+    const username = 'octocat';
+    const repositoryName = 'hello-world';
+    const accessToken = 'gho_912e0asd0q821edqd';
+    const response = {
+      status: 200,
+      data: {
+        name: repositoryName,
+        parent: {
+          owner: {
+            login: 'rodrigo-md',
+          },
+        },
+        owner: {
+          login: username,
+        },
+        private: false,
+        fork: true,
+      },
+    };
+    const httpClient = { get: jest.fn().mockResolvedValue(response) };
+    const getRepository = createGetRepository(
+      httpClient as unknown as HttpClient,
+    );
+
+    const result = await getRepository(accessToken, username, repositoryName);
+
+    expect(result.isOk()).toBe(true);
+    expect(result.value).toEqual({
+      name: repositoryName,
+      owner: 'rodrigo-md',
+      isPublic: true,
+      isFork: true,
+    });
+  });
+
+  test('throw RequiresAuthentication error when receives a 401', async () => {
+    const username = 'octocat';
+    const repositoryName = 'hello-world';
+    const accessToken = 'gho_912e0asd0q821edqd';
+    const response = { status: 401 };
+    const httpClient = { get: jest.fn().mockRejectedValue({ response }) };
+    const getRepository = createGetRepository(
+      httpClient as unknown as HttpClient,
+    );
+
+    await expect(() =>
+      getRepository(accessToken, username, repositoryName),
+    ).rejects.toThrow(githubErrors.RequiresAuthentication);
+  });
+
+  test('throw Forbidden error when receives a 403', async () => {
+    const username = 'octocat';
+    const repositoryName = 'hello-world';
+    const accessToken = 'gho_912e0asd0q821edqd';
+    const response = { status: 403 };
+    const httpClient = { get: jest.fn().mockRejectedValue({ response }) };
+    const getRepository = createGetRepository(
+      httpClient as unknown as HttpClient,
+    );
+
+    await expect(() =>
+      getRepository(accessToken, username, repositoryName),
+    ).rejects.toThrow(githubErrors.Forbidden);
+  });
+
+  test('returns a result error when the repository cannot be found', async () => {
+    const username = 'octocat';
+    const repositoryName = 'hello-world';
+    const accessToken = 'gho_912e0asd0q821edqd';
+    const response = { status: 404 };
+    const httpClient = { get: jest.fn().mockRejectedValue({ response }) };
+    const getRepository = createGetRepository(
+      httpClient as unknown as HttpClient,
+    );
+
+    const result = await getRepository(accessToken, username, repositoryName);
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.value).toEqual(expect.any(Object));
+      expect(result.value.type).toEqual('NotFound');
+    }
+  });
+
+  test('throw any other error as it is', async () => {
+    const username = 'octocat';
+    const repositoryName = 'hello-world';
+    const accessToken = 'gho_912e0asd0q821edqd';
+    const customError = new Error('custom error');
+    const httpClient = { get: jest.fn().mockRejectedValue(customError) };
+    const getRepository = createGetRepository(
+      httpClient as unknown as HttpClient,
+    );
+
+    await expect(() =>
+      getRepository(accessToken, username, repositoryName),
+    ).rejects.toThrow(customError);
+  });
+
+  test('throw any other http error as Unknown', async () => {
+    const username = 'octocat';
+    const repositoryName = 'hello-world';
+    const accessToken = 'gho_912e0asd0q821edqd';
+    const response = { status: 503, data: 'Service Unavailable' };
+    const httpClient = { get: jest.fn().mockRejectedValue({ response }) };
+    const getRepository = createGetRepository(
+      httpClient as unknown as HttpClient,
+    );
+
+    await expect(() =>
+      getRepository(accessToken, username, repositoryName),
+    ).rejects.toThrow(githubErrors.Unknown);
+  });
+});

--- a/apps/api/src/adapters/clients/github/errors.ts
+++ b/apps/api/src/adapters/clients/github/errors.ts
@@ -42,8 +42,24 @@ export class ValidationFailed extends Error {
   }
 }
 
+export class NotFound extends Error {
+  constructor(message?: string) {
+    super(message ?? 'Not Found');
+    Object.setPrototypeOf(this, NotFound.prototype);
+  }
+}
+
+export class Unknown extends Error {
+  constructor(message: string) {
+    super(message);
+    Object.setPrototypeOf(this, Unknown.prototype);
+  }
+}
+
 export const isGithubError = (err: Error): boolean => {
   switch (true) {
+    case err instanceof Unknown:
+    case err instanceof NotFound:
     case err instanceof Forbidden:
     case err instanceof ValidationFailed:
     case err instanceof AccessTokenNotFound:
@@ -63,4 +79,6 @@ export default {
   RequiresAuthentication,
   Forbidden,
   ValidationFailed,
+  NotFound,
+  Unknown,
 };

--- a/apps/api/src/adapters/clients/github/get-access-token.ts
+++ b/apps/api/src/adapters/clients/github/get-access-token.ts
@@ -40,6 +40,7 @@ export function createGetAccessToken(
           }
         }
       }
+      // TODO: throw new Unknown(e.message);
       throw e;
     }
   };

--- a/apps/api/src/adapters/clients/github/get-repository.ts
+++ b/apps/api/src/adapters/clients/github/get-repository.ts
@@ -1,0 +1,60 @@
+import { Forbidden, RequiresAuthentication, Unknown } from './errors';
+import { ok, err } from '../../../domain/utilities';
+import { RepositoryErrors } from '../../../domain/use-cases/interfaces';
+import type { HttpClient } from './interfaces/dependencies';
+import type { GithubRepository } from './interfaces/repository';
+import type { Result, ErrReason } from '../../../domain/use-cases/interfaces';
+import type { Repository } from '../../../domain/use-cases/interfaces/repository';
+
+export function createGetRepository(httpClient: HttpClient) {
+  return async (
+    accessToken: string,
+    owner: string,
+    repositoryName: string,
+  ): Promise<Result<Repository, ErrReason<RepositoryErrors.NotFound>>> => {
+    try {
+      const response = await httpClient.get<GithubRepository>(
+        `https://api.github.com/repos/${owner}/${repositoryName}`,
+        {
+          headers: {
+            authorization: `token ${accessToken}`,
+            accept: 'application/vnd.github+json',
+          },
+        },
+      );
+
+      const {
+        private: isPrivate,
+        fork,
+        parent = { owner: { login: '' } },
+      } = response.data;
+
+      return ok({
+        name: repositoryName,
+        owner: fork ? parent.owner.login : owner,
+        isPublic: !isPrivate,
+        isFork: fork,
+      });
+    } catch (e) {
+      if (e.response && e.response.status) {
+        switch (e.response.status) {
+          case 401: {
+            throw new RequiresAuthentication();
+          }
+          case 403: {
+            throw new Forbidden();
+          }
+          case 404: {
+            return err({
+              type: RepositoryErrors.NotFound,
+            });
+          }
+          default: {
+            throw new Unknown(e.response.data);
+          }
+        }
+      }
+      throw e;
+    }
+  };
+}

--- a/apps/api/src/adapters/clients/github/get-user.ts
+++ b/apps/api/src/adapters/clients/github/get-user.ts
@@ -31,6 +31,7 @@ export function createGetUser(httpClient: HttpClient) {
           }
         }
       }
+      // TODO: throw new Unknown(e.message);
       throw e;
     }
   };

--- a/apps/api/src/adapters/clients/github/index.ts
+++ b/apps/api/src/adapters/clients/github/index.ts
@@ -1,12 +1,14 @@
 import { createGetUser } from './get-user';
 import { createGetAccessToken } from './get-access-token';
-import { createListUserRepositories } from './list-user-repositories';
+import { createListUserCollaborations } from './list-user-collaborations';
+import { createGetRepository } from './get-repository';
 import type { HttpClient, GithubConfig } from './interfaces/dependencies';
 
 export default (httpClient: HttpClient, config: GithubConfig) => {
   return {
     getUser: createGetUser(httpClient),
     getAccessToken: createGetAccessToken(httpClient, config),
-    listUserRepositories: createListUserRepositories(httpClient),
+    listUserCollaborations: createListUserCollaborations(httpClient),
+    getRepository: createGetRepository(httpClient),
   };
 };

--- a/apps/api/src/adapters/clients/github/interfaces/repository.ts
+++ b/apps/api/src/adapters/clients/github/interfaces/repository.ts
@@ -20,4 +20,11 @@ export interface GithubRepository {
 
   // https://api.github.com/repos/<owner>/<repository name>
   url: string;
+
+  // Repository visibility
+  private: boolean;
+
+  fork: boolean;
+
+  parent?: GithubRepository;
 }

--- a/apps/api/src/adapters/handlers/__tests__/authentication.test.ts
+++ b/apps/api/src/adapters/handlers/__tests__/authentication.test.ts
@@ -184,6 +184,7 @@ describe('Authentication middleware', () => {
       'githubToken',
       tokenCookie.githubToken,
     );
+    expect(ctxt.store).toHaveBeenCalledWith('username', authCookie.username);
     expect(ctxt.next).toHaveBeenCalled();
   });
 });

--- a/apps/api/src/adapters/handlers/__tests__/validate-repository-affiliation.test.ts
+++ b/apps/api/src/adapters/handlers/__tests__/validate-repository-affiliation.test.ts
@@ -5,36 +5,28 @@ import { createValidateRepositoryAffiliationHandler } from '../validate-reposito
 import githubErrors from '../../clients/github/errors';
 
 describe('Validate repository affiliation handler', () => {
-  test("throws Http Not Found when repository isn't in the user's repository list", async () => {
+  test('returns 200 when the user authenticated is the repository owner', async () => {
+    const username = 'octocat';
+    const repositoryName = 'hello-world';
+    const githubToken = 'gho_89as8d9as781e9hq9uhd';
+    const result = makeResultOk({
+      name: repositoryName,
+      owner: username,
+      isPublic: true,
+      isFork: false,
+    });
     const githubClient = {
-      listUserRepositories: jest.fn().mockResolvedValue([]),
+      getRepository: jest.fn().mockResolvedValue(result),
+      listUserCollaborations: jest.fn().mockResolvedValue([]),
     };
     const handler = createValidateRepositoryAffiliationHandler(githubClient);
 
     const ctxt = {
-      pathParams: jest.fn().mockReturnValue({ repositoryName: 'supertest' }),
-      retrieveFromStore: jest.fn().mockReturnValue('gho_a98sda8s9fya9'),
-      status: jest.fn(),
-    };
-
-    try {
-      await handler(ctxt as unknown as HttpContext);
-      expect.hasAssertions();
-    } catch (e) {
-      expect(ctxt.pathParams).toHaveBeenCalled();
-      expect(e).toBeInstanceOf(httpErrors.NotFound);
-    }
-  });
-
-  test("returns 200 when the repository is in the user's repository list", async () => {
-    const githubClient = {
-      listUserRepositories: jest.fn().mockResolvedValue([{ name: 'supertest' }]),
-    };
-    const handler = createValidateRepositoryAffiliationHandler(githubClient);
-
-    const ctxt = {
-      pathParams: jest.fn().mockReturnValue({ repositoryName: 'supertest' }),
-      retrieveFromStore: jest.fn().mockReturnValue('gho_a98sda8s9fya9'),
+      pathParams: jest.fn().mockReturnValueOnce({ repositoryName }),
+      retrieveFromStore: jest
+        .fn()
+        .mockReturnValueOnce(githubToken)
+        .mockReturnValueOnce(username),
       status: jest.fn(),
       send: jest.fn(),
     };
@@ -42,13 +34,239 @@ describe('Validate repository affiliation handler', () => {
     await handler(ctxt as unknown as HttpContext);
 
     expect(ctxt.retrieveFromStore).toHaveBeenCalledWith('githubToken');
+    expect(ctxt.retrieveFromStore).toHaveBeenCalledWith('username');
     expect(ctxt.status).toHaveBeenCalledWith(200);
-    expect(ctxt.send).toHaveBeenCalledWith({ message: 'Ok' });
+    expect(ctxt.send).toHaveBeenCalledWith({
+      name: repositoryName,
+      owner: username,
+      isPublic: true,
+      isFork: false,
+    });
+  });
+
+  test("returns 200 when the repository is contained in the list of user's collaborations", async () => {
+    const username = 'octocat';
+    const repositoryName = 'hello-world';
+    const githubToken = 'gho_89as8d9as781e9hq9uhd';
+    const result = makeResultErr({ type: 'NotFound' });
+    const githubClient = {
+      getRepository: jest.fn().mockResolvedValue(result),
+      listUserCollaborations: jest.fn().mockResolvedValue([
+        {
+          name: 'can-i-help',
+          owner: 'rodrigo-md',
+          isFork: true,
+          isPublic: true,
+        },
+        {
+          name: repositoryName,
+          owner: username,
+          isFork: false,
+          isPublic: true,
+        },
+        {
+          name: 'my-company-product',
+          owner: 'boss',
+          isFork: true,
+          isPublic: true,
+        },
+      ]),
+    };
+    const handler = createValidateRepositoryAffiliationHandler(githubClient);
+
+    const ctxt = {
+      pathParams: jest.fn().mockReturnValueOnce({ repositoryName }),
+      retrieveFromStore: jest
+        .fn()
+        .mockReturnValueOnce(githubToken)
+        .mockReturnValueOnce(username),
+      status: jest.fn(),
+      send: jest.fn(),
+    };
+
+    await handler(ctxt as unknown as HttpContext);
+
+    expect(githubClient.getRepository).toHaveBeenCalled();
+    expect(githubClient.listUserCollaborations).toHaveBeenCalled();
+    expect(ctxt.status).toHaveBeenCalledWith(200);
+    expect(ctxt.send).toHaveBeenCalledWith({
+      name: repositoryName,
+      owner: username,
+      isFork: false,
+      isPublic: true,
+    });
+  });
+
+  test("throws Http Not Found when the authenticated user doesn't own the repo neither is a collaboration", async () => {
+    const result = makeResultErr({ type: 'NotFound' });
+    const githubClient = {
+      getRepository: jest.fn().mockResolvedValue(result),
+      listUserCollaborations: jest.fn().mockResolvedValue([]),
+    };
+    const handler = createValidateRepositoryAffiliationHandler(githubClient);
+
+    const ctxt = {
+      pathParams: jest.fn().mockReturnValue({ repositoryName: 'supertest' }),
+      retrieveFromStore: jest
+        .fn()
+        .mockReturnValueOnce('gho_a98sda8s9fya9')
+        .mockReturnValueOnce('octocat'),
+      status: jest.fn(),
+    };
+
+    await expect(() => handler(ctxt as unknown as HttpContext)).rejects.toThrow(
+      httpErrors.NotFound,
+    );
+  });
+  test('throws Http Not Found when the authenticated user is the owner but the repository is private', async () => {
+    const result = makeResultOk({
+      name: 'hello-world',
+      owner: 'octocat',
+      isPublic: false,
+      isFork: false,
+    });
+    const githubClient = {
+      getRepository: jest.fn().mockResolvedValue(result),
+      listUserCollaborations: jest.fn().mockResolvedValue([]),
+    };
+    const handler = createValidateRepositoryAffiliationHandler(githubClient);
+
+    const ctxt = {
+      pathParams: jest.fn().mockReturnValue({ repositoryName: 'supertest' }),
+      retrieveFromStore: jest
+        .fn()
+        .mockReturnValueOnce('gho_a98sda8s9fya9')
+        .mockReturnValueOnce('octocat'),
+      status: jest.fn(),
+    };
+
+    await expect(() => handler(ctxt as unknown as HttpContext)).rejects.toThrow(
+      httpErrors.NotFound,
+    );
+  });
+
+  test('throws Http Not Found when the authenticated user is the owner but the repository is a fork', async () => {
+    const result = makeResultOk({
+      name: 'hello-world',
+      owner: 'octocat',
+      isPublic: true,
+      isFork: true,
+    });
+    const githubClient = {
+      getRepository: jest.fn().mockResolvedValue(result),
+      listUserCollaborations: jest.fn().mockResolvedValue([]),
+    };
+    const handler = createValidateRepositoryAffiliationHandler(githubClient);
+
+    const ctxt = {
+      pathParams: jest.fn().mockReturnValue({ repositoryName: 'supertest' }),
+      retrieveFromStore: jest
+        .fn()
+        .mockReturnValueOnce('gho_a98sda8s9fya9')
+        .mockReturnValueOnce('octocat'),
+      status: jest.fn(),
+    };
+
+    await expect(() => handler(ctxt as unknown as HttpContext)).rejects.toThrow(
+      httpErrors.NotFound,
+    );
+  });
+
+  test("throws Http Not Found when the repository is found as a collaboration but it's private", async () => {
+    const username = 'octocat';
+    const repositoryName = 'hello-world';
+    const githubToken = 'gho_89as8d9as781e9hq9uhd';
+    const result = makeResultErr({ type: 'NotFound' });
+    const githubClient = {
+      getRepository: jest.fn().mockResolvedValue(result),
+      listUserCollaborations: jest.fn().mockResolvedValue([
+        {
+          name: 'can-i-help',
+          owner: 'rodrigo-md',
+          isFork: true,
+          isPublic: true,
+        },
+        {
+          name: repositoryName,
+          owner: username,
+          isFork: false,
+          isPublic: false,
+        },
+        {
+          name: 'my-company-product',
+          owner: 'boss',
+          isFork: true,
+          isPublic: true,
+        },
+      ]),
+    };
+    const handler = createValidateRepositoryAffiliationHandler(githubClient);
+
+    const ctxt = {
+      pathParams: jest.fn().mockReturnValueOnce({ repositoryName }),
+      retrieveFromStore: jest
+        .fn()
+        .mockReturnValueOnce(githubToken)
+        .mockReturnValueOnce(username),
+      status: jest.fn(),
+      send: jest.fn(),
+    };
+
+    await expect(() => handler(ctxt as unknown as HttpContext)).rejects.toThrow(
+      httpErrors.NotFound,
+    );
+  });
+
+  test("throws Http Not Found when the repository is found as a collaboration but it's a fork", async () => {
+    const username = 'octocat';
+    const repositoryName = 'hello-world';
+    const githubToken = 'gho_89as8d9as781e9hq9uhd';
+    const result = makeResultErr({ type: 'NotFound' });
+    const githubClient = {
+      getRepository: jest.fn().mockResolvedValue(result),
+      listUserCollaborations: jest.fn().mockResolvedValue([
+        {
+          name: 'can-i-help',
+          owner: 'rodrigo-md',
+          isFork: true,
+          isPublic: true,
+        },
+        {
+          name: repositoryName,
+          owner: username,
+          isFork: true,
+          isPublic: true,
+        },
+        {
+          name: 'my-company-product',
+          owner: 'boss',
+          isFork: true,
+          isPublic: true,
+        },
+      ]),
+    };
+    const handler = createValidateRepositoryAffiliationHandler(githubClient);
+
+    const ctxt = {
+      pathParams: jest.fn().mockReturnValueOnce({ repositoryName }),
+      retrieveFromStore: jest
+        .fn()
+        .mockReturnValueOnce(githubToken)
+        .mockReturnValueOnce(username),
+      status: jest.fn(),
+      send: jest.fn(),
+    };
+
+    await expect(() => handler(ctxt as unknown as HttpContext)).rejects.toThrow(
+      httpErrors.NotFound,
+    );
   });
 
   test('throw an Http 500 when receives a github validation error', async () => {
+    const result = makeResultErr({ type: 'NotFound ' });
     const githubClient = {
-      listUserRepositories: jest
+      getRepository: jest.fn().mockResolvedValue(result),
+      listUserCollaborations: jest
         .fn()
         .mockRejectedValue(new githubErrors.ValidationFailed()),
     };
@@ -56,7 +274,10 @@ describe('Validate repository affiliation handler', () => {
 
     const ctxt = {
       pathParams: jest.fn().mockReturnValue({ repositoryName: 'supertest' }),
-      retrieveFromStore: jest.fn().mockReturnValue('gho_a98sda8s9fya9'),
+      retrieveFromStore: jest
+        .fn()
+        .mockReturnValueOnce('gho_a98sda8s9fya9')
+        .mockReturnValueOnce('octocat'),
       status: jest.fn(),
       send: jest.fn(),
     };
@@ -66,9 +287,11 @@ describe('Validate repository affiliation handler', () => {
     );
   });
 
-  test('throw an Http 403 when receives a github forbidden error', async () => {
+  test('throw an Http 403 when receives a 403 looking for the repo in the list of collaborations', async () => {
+    const result = makeResultErr({ type: 'NotFound' });
     const githubClient = {
-      listUserRepositories: jest
+      getRepository: jest.fn().mockResolvedValue(result),
+      listUserCollaborations: jest
         .fn()
         .mockRejectedValue(new githubErrors.Forbidden()),
     };
@@ -76,7 +299,10 @@ describe('Validate repository affiliation handler', () => {
 
     const ctxt = {
       pathParams: jest.fn().mockReturnValue({ repositoryName: 'supertest' }),
-      retrieveFromStore: jest.fn().mockReturnValue('gho_a98sda8s9fya9'),
+      retrieveFromStore: jest
+        .fn()
+        .mockReturnValueOnce('gho_a98sda8s9fya9')
+        .mockReturnValueOnce('octocat'),
       status: jest.fn(),
       send: jest.fn(),
     };
@@ -86,9 +312,33 @@ describe('Validate repository affiliation handler', () => {
     );
   });
 
-  test('throw an Http 403 when receives a github requires authentication error', async () => {
+  test("throw an Http 403 when receives a 403 looking for the repo as one of the authenticated user's repos", async () => {
     const githubClient = {
-      listUserRepositories: jest
+      getRepository: jest.fn().mockRejectedValue(new githubErrors.Forbidden()),
+      listUserCollaborations: jest.fn(),
+    };
+    const handler = createValidateRepositoryAffiliationHandler(githubClient);
+
+    const ctxt = {
+      pathParams: jest.fn().mockReturnValue({ repositoryName: 'supertest' }),
+      retrieveFromStore: jest
+        .fn()
+        .mockReturnValueOnce('gho_a98sda8s9fya9')
+        .mockReturnValueOnce('octocat'),
+      status: jest.fn(),
+      send: jest.fn(),
+    };
+
+    await expect(() => handler(ctxt as unknown as HttpContext)).rejects.toThrow(
+      httpErrors.Forbidden,
+    );
+  });
+
+  test('throw an Http 403 when receives a 401 looking for the repo in the list of collaborations', async () => {
+    const result = makeResultErr({ type: 'NotFound' });
+    const githubClient = {
+      getRepository: jest.fn().mockResolvedValue(result),
+      listUserCollaborations: jest
         .fn()
         .mockRejectedValue(new githubErrors.RequiresAuthentication()),
     };
@@ -96,7 +346,10 @@ describe('Validate repository affiliation handler', () => {
 
     const ctxt = {
       pathParams: jest.fn().mockReturnValue({ repositoryName: 'supertest' }),
-      retrieveFromStore: jest.fn().mockReturnValue('gho_a98sda8s9fya9'),
+      retrieveFromStore: jest
+        .fn()
+        .mockReturnValueOnce('gho_a98sda8s9fya9')
+        .mockReturnValueOnce('octocat'),
       status: jest.fn(),
       send: jest.fn(),
     };
@@ -106,15 +359,98 @@ describe('Validate repository affiliation handler', () => {
     );
   });
 
-  test('throw any other unexpected error', async () => {
+  test("throw an Http 403 when receives a 401 looking for the repo as one of the authenticated user's repos", async () => {
     const githubClient = {
-      listUserRepositories: jest.fn().mockResolvedValue([{ name: 'supertest' }]),
+      getRepository: jest
+        .fn()
+        .mockRejectedValue(new githubErrors.RequiresAuthentication()),
+      listUserCollaborations: jest.fn(),
     };
     const handler = createValidateRepositoryAffiliationHandler(githubClient);
-    const customError = new TypeError('cannot parse invalid json');
+
     const ctxt = {
       pathParams: jest.fn().mockReturnValue({ repositoryName: 'supertest' }),
-      retrieveFromStore: jest.fn().mockReturnValue('gho_a98sda8s9fya9'),
+      retrieveFromStore: jest
+        .fn()
+        .mockReturnValueOnce('gho_a98sda8s9fya9')
+        .mockReturnValueOnce('octocat'),
+      status: jest.fn(),
+      send: jest.fn(),
+    };
+
+    await expect(() => handler(ctxt as unknown as HttpContext)).rejects.toThrow(
+      httpErrors.Forbidden,
+    );
+  });
+
+  test('throw an Http 502 when get an unknown error looking for the repo in the list of collaborations', async () => {
+    const result = makeResultErr({ type: 'NotFound' });
+    const githubClient = {
+      getRepository: jest.fn().mockResolvedValue(result),
+      listUserCollaborations: jest
+        .fn()
+        .mockRejectedValue(new githubErrors.Unknown('Server Unavailable')),
+    };
+    const handler = createValidateRepositoryAffiliationHandler(githubClient);
+
+    const ctxt = {
+      pathParams: jest.fn().mockReturnValue({ repositoryName: 'supertest' }),
+      retrieveFromStore: jest
+        .fn()
+        .mockReturnValueOnce('gho_a98sda8s9fya9')
+        .mockReturnValueOnce('octocat'),
+      status: jest.fn(),
+      send: jest.fn(),
+    };
+
+    await expect(() => handler(ctxt as unknown as HttpContext)).rejects.toThrow(
+      httpErrors.BadGateway,
+    );
+  });
+
+  test("throw an Http 502 when get an unknown error looking for the repo as one of the authenticated user's repos", async () => {
+    const githubClient = {
+      getRepository: jest
+        .fn()
+        .mockRejectedValue(new githubErrors.Unknown('Internal Server Error')),
+      listUserCollaborations: jest.fn(),
+    };
+    const handler = createValidateRepositoryAffiliationHandler(githubClient);
+
+    const ctxt = {
+      pathParams: jest.fn().mockReturnValue({ repositoryName: 'supertest' }),
+      retrieveFromStore: jest
+        .fn()
+        .mockReturnValueOnce('gho_a98sda8s9fya9')
+        .mockReturnValueOnce('octocat'),
+      status: jest.fn(),
+      send: jest.fn(),
+    };
+
+    await expect(() => handler(ctxt as unknown as HttpContext)).rejects.toThrow(
+      httpErrors.BadGateway,
+    );
+  });
+
+  test('throw any other unexpected error', async () => {
+    const result = makeResultOk({
+      name: 'hello-world',
+      owner: 'octocat',
+      isPublic: true,
+      isFork: false,
+    });
+    const customError = new TypeError('cannot parse invalid json');
+    const githubClient = {
+      getRepository: jest.fn().mockResolvedValue(result),
+      listUserCollaborations: jest.fn(),
+    };
+    const handler = createValidateRepositoryAffiliationHandler(githubClient);
+    const ctxt = {
+      pathParams: jest.fn().mockReturnValue({ repositoryName: 'supertest' }),
+      retrieveFromStore: jest
+        .fn()
+        .mockReturnValue('gho_a98sda8s9fya9')
+        .mockReturnValueOnce('octocat'),
       status: jest.fn(),
       send: jest.fn().mockImplementation(() => {
         throw customError;
@@ -126,3 +462,19 @@ describe('Validate repository affiliation handler', () => {
     );
   });
 });
+
+function makeResultOk(value) {
+  return {
+    isOk: () => true,
+    isErr: () => false,
+    value: value,
+  };
+}
+
+function makeResultErr(value) {
+  return {
+    isOk: () => false,
+    isErr: () => true,
+    value: value,
+  };
+}

--- a/apps/api/src/adapters/handlers/authentication.ts
+++ b/apps/api/src/adapters/handlers/authentication.ts
@@ -70,6 +70,7 @@ export const createAuthenticationHandler = (
       await authenticateUserUseCase(jwt, publicCookie, privateCookie, config);
 
       ctxt.store('githubToken', privateCookie.githubToken);
+      ctxt.store('username', publicCookie.username);
       ctxt.next();
     } catch (e) {
       switch (true) {

--- a/apps/api/src/adapters/handlers/validate-repository-affiliation.ts
+++ b/apps/api/src/adapters/handlers/validate-repository-affiliation.ts
@@ -12,7 +12,6 @@ export const createValidateRepositoryAffiliationHandler = (
     try {
       const { repositoryName } = ctxt.pathParams<{ repositoryName: string }>();
       const githubToken = ctxt.retrieveFromStore<string>('githubToken');
-      // TODO: store username in the authentication handler
       const username = ctxt.retrieveFromStore<string>('username');
 
       const repository = await validateRepositoryAffiliationUseCase(

--- a/apps/api/src/domain/use-cases/interfaces/index.ts
+++ b/apps/api/src/domain/use-cases/interfaces/index.ts
@@ -1,0 +1,42 @@
+export enum RepositoryErrors {
+  NotFound = 'NotFound',
+}
+
+export interface ErrReason<R extends string> {
+  type: R;
+  reason?: Error;
+}
+
+export type Result<S, F> = Ok<S, F> | Err<S, F>;
+
+export class Ok<S, F> {
+  readonly value: S;
+
+  constructor(value: S) {
+    this.value = value;
+  }
+
+  isOk(): this is Ok<S, F> {
+    return true;
+  }
+
+  isErr(): this is Err<S, F> {
+    return false;
+  }
+}
+
+export class Err<S, F> {
+  readonly value: F;
+
+  constructor(value: F) {
+    this.value = value;
+  }
+
+  isOk(): this is Ok<S, F> {
+    return false;
+  }
+
+  isErr(): this is Err<S, F> {
+    return true;
+  }
+}

--- a/apps/api/src/domain/use-cases/interfaces/repository.ts
+++ b/apps/api/src/domain/use-cases/interfaces/repository.ts
@@ -1,0 +1,6 @@
+export interface Repository {
+  name: string;
+  owner: string;
+  isPublic: boolean;
+  isFork: boolean;
+}

--- a/apps/api/src/domain/use-cases/validate-repository-affiliation/index.ts
+++ b/apps/api/src/domain/use-cases/validate-repository-affiliation/index.ts
@@ -1,20 +1,52 @@
+import { Repository } from '../interfaces/repository';
 import { NonExistentRepository } from './errors';
+import type { ErrReason, RepositoryErrors, Result } from '../interfaces';
 
 export interface GithubClient {
-  listUserRepositories(token: unknown): Promise<{ name: string }[]>;
+  getRepository(
+    token: string,
+    owner: string,
+    repositoryName: string
+  ): Promise<Result<Repository, ErrReason<RepositoryErrors.NotFound>>>;
+  listUserCollaborations(token: unknown): Promise<Repository[]>;
+}
+
+export interface RepositoryAffiliationDTO {
+  githubToken: string;
+  username: string;
+  repositoryName: string;
 }
 
 export const validateRepositoryAffiliationUseCase = async (
   githubClient: GithubClient,
-  githubToken: unknown,
-  repositoryName: string,
-) => {
-  const repositories = await githubClient.listUserRepositories(githubToken);
-  const findings = repositories.filter(
-    (repository) => repository.name === repositoryName,
+  data: RepositoryAffiliationDTO,
+): Promise<Repository> => {
+  const { githubToken, username, repositoryName } = data;
+
+  const result = await githubClient.getRepository(
+    githubToken,
+    username,
+    repositoryName,
   );
 
-  if (findings.length === 0) {
-    throw new NonExistentRepository(repositoryName);
+  if (
+    result.isErr() ||
+    (result.isOk() && (!result.value.isPublic || result.value.isFork))
+  ) {
+    const repositories = await githubClient.listUserCollaborations(githubToken);
+    const findings = repositories.filter(
+      (repository) =>
+        repository.name === repositoryName &&
+        repository.isPublic &&
+        !repository.isFork,
+    );
+
+    if (findings.length === 0) {
+      throw new NonExistentRepository(repositoryName);
+    }
+
+    return findings[0];
   }
+
+  return result.value;
 };

--- a/apps/api/src/domain/utilities/index.ts
+++ b/apps/api/src/domain/utilities/index.ts
@@ -1,0 +1,9 @@
+import { Result, Ok, Err } from '../use-cases/interfaces';
+
+export const err = <S, F>(v: F): Result<S, F> => {
+  return new Err<S, F>(v);
+};
+
+export const ok = <S, F>(v: S): Result<S, F> => {
+  return new Ok(v);
+};


### PR DESCRIPTION
query two different endpoints from Github API to return the repository only if it's public and not a fork
